### PR TITLE
role memberships are emitted as user grants, so don't skip running user grants

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -24,7 +24,6 @@ var (
 		Traits: []v2.ResourceType_Trait{
 			v2.ResourceType_TRAIT_USER,
 		},
-		Annotations: annotationsForUserResourceType(),
 	}
 	resourceTypeWorkspace = &v2.ResourceType{
 		Id:          "workspace",

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -28,12 +28,6 @@ func parsePageToken(i string, resourceID *v2.ResourceId) (*pagination.Bag, error
 	return b, nil
 }
 
-func annotationsForUserResourceType() annotations.Annotations {
-	annos := annotations.Annotations{}
-	annos.Update(&v2.SkipEntitlementsAndGrants{})
-	return annos
-}
-
 func annotationsForError(err error) (annotations.Annotations, error) {
 	annos := annotations.Annotations{}
 	var rateLimitErr *slack.RateLimitedError


### PR DESCRIPTION
This annotation prevents the syncer from calling list grants on the user type resource, so no role grants are being created.