### PR TITLE
Enterprise cleanup and stuff

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -110,6 +110,9 @@ func New(ctx context.Context, apiKey, enterpriseKey string, ssoEnabled bool) (*S
 	var enterpriseId string
 	if res.EnterpriseID != "" {
 		enterpriseId = res.EnterpriseID
+		if enterpriseKey == "" {
+			return nil, fmt.Errorf("slack-connector: enterprise account detected, but no enterprise token specified")
+		}
 	}
 	enterpriseClient := enterprise.NewClient(httpClient, enterpriseKey, apiKey, res.EnterpriseID, ssoEnabled)
 
@@ -124,7 +127,7 @@ func New(ctx context.Context, apiKey, enterpriseKey string, ssoEnabled bool) (*S
 
 func (s *Slack) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncer {
 	return []connectorbuilder.ResourceSyncer{
-		userBuilder(s.client, s.enterpriseID, s.enterpriseClient),
+		userBuilder(s.client),
 		workspaceBuilder(s.client, s.enterpriseID, s.enterpriseClient),
 		userGroupBuilder(s.client, s.enterpriseID, s.enterpriseClient),
 		workspaceRoleBuilder(s.client, s.enterpriseClient),

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -127,7 +127,7 @@ func New(ctx context.Context, apiKey, enterpriseKey string, ssoEnabled bool) (*S
 
 func (s *Slack) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncer {
 	return []connectorbuilder.ResourceSyncer{
-		userBuilder(s.client),
+		userBuilder(s.client, s.enterpriseID, s.enterpriseClient),
 		workspaceBuilder(s.client, s.enterpriseID, s.enterpriseClient),
 		userGroupBuilder(s.client, s.enterpriseID, s.enterpriseClient),
 		workspaceRoleBuilder(s.client, s.enterpriseClient),

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -8,12 +8,15 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/helpers"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/types/resource"
+	enterprise "github.com/conductorone/baton-slack/pkg/slack"
 	"github.com/slack-go/slack"
 )
 
 type userResourceType struct {
-	resourceType *v2.ResourceType
-	client       *slack.Client
+	resourceType     *v2.ResourceType
+	client           *slack.Client
+	enterpriseID     string
+	enterpriseClient *enterprise.Client
 }
 
 func (o *userResourceType) ResourceType(_ context.Context) *v2.ResourceType {
@@ -141,9 +144,11 @@ func (o *userResourceType) List(ctx context.Context, parentResourceID *v2.Resour
 	return rv, pageToken, nil, nil
 }
 
-func userBuilder(client *slack.Client) *userResourceType {
+func userBuilder(client *slack.Client, enterpriseID string, enterpriseClient *enterprise.Client) *userResourceType {
 	return &userResourceType{
-		resourceType: resourceTypeUser,
-		client:       client,
+		resourceType:     resourceTypeUser,
+		client:           client,
+		enterpriseID:     enterpriseID,
+		enterpriseClient: enterpriseClient,
 	}
 }

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -8,15 +8,12 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/helpers"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/types/resource"
-	enterprise "github.com/conductorone/baton-slack/pkg/slack"
 	"github.com/slack-go/slack"
 )
 
 type userResourceType struct {
-	resourceType     *v2.ResourceType
-	client           *slack.Client
-	enterpriseID     string
-	enterpriseClient *enterprise.Client
+	resourceType *v2.ResourceType
+	client       *slack.Client
 }
 
 func (o *userResourceType) ResourceType(_ context.Context) *v2.ResourceType {
@@ -144,11 +141,9 @@ func (o *userResourceType) List(ctx context.Context, parentResourceID *v2.Resour
 	return rv, pageToken, nil, nil
 }
 
-func userBuilder(client *slack.Client, enterpriseID string, enterpriseClient *enterprise.Client) *userResourceType {
+func userBuilder(client *slack.Client) *userResourceType {
 	return &userResourceType{
-		resourceType:     resourceTypeUser,
-		client:           client,
-		enterpriseID:     enterpriseID,
-		enterpriseClient: enterpriseClient,
+		resourceType: resourceTypeUser,
+		client:       client,
 	}
 }

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -34,14 +34,27 @@ func userResource(ctx context.Context, user *slack.User, parentResourceID *v2.Re
 	profile["status_text"] = user.Profile.StatusText
 	profile["status_emoji"] = user.Profile.StatusEmoji
 
-	var userStatus v2.UserTrait_Status_Status
-	if user.Deleted {
-		userStatus = v2.UserTrait_Status_STATUS_DELETED
-	} else {
-		userStatus = v2.UserTrait_Status_STATUS_ENABLED
+	userTraitOptions := []resource.UserTraitOption{
+		resource.WithUserProfile(profile),
+		resource.WithEmail(user.Profile.Email, true),
 	}
 
-	userTraitOptions := []resource.UserTraitOption{resource.WithUserProfile(profile), resource.WithEmail(user.Profile.Email, true), resource.WithStatus(userStatus)}
+	userStatus := v2.UserTrait_Status_STATUS_ENABLED
+	if user.Deleted {
+		userStatus = v2.UserTrait_Status_STATUS_DELETED
+	}
+	userTraitOptions = append(userTraitOptions, resource.WithStatus(userStatus))
+
+	if user.IsBot {
+		userTraitOptions = append(userTraitOptions, resource.WithAccountType(v2.UserTrait_ACCOUNT_TYPE_SERVICE))
+	}
+
+	// If the credentials we're hitting the API with don't have admin, this can be false even if the user has mfa enabled
+	// See https://api.slack.com/types/user for more info
+	if user.Has2FA {
+		userTraitOptions = append(userTraitOptions, resource.WithMFAStatus(&v2.UserTrait_MFAStatus{MfaEnabled: true}))
+	}
+
 	ret, err := resource.NewUserResource(user.Name, resourceTypeUser, user.ID, userTraitOptions, resource.WithParentResourceID(parentResourceID))
 	if err != nil {
 		return nil, err
@@ -69,7 +82,29 @@ func baseUserResource(ctx context.Context, user enterprise.UserAdmin) (*v2.Resou
 		userStatus = v2.UserTrait_Status_STATUS_DISABLED
 	}
 
-	userTraitOptions := []resource.UserTraitOption{resource.WithUserProfile(profile), resource.WithEmail(user.Email, true), resource.WithStatus(userStatus)}
+	userTraitOptions := []resource.UserTraitOption{
+		resource.WithUserProfile(profile),
+		resource.WithEmail(user.Email, true),
+		resource.WithStatus(userStatus),
+		resource.WithUserLogin(user.Username),
+	}
+
+	if user.IsBot {
+		userTraitOptions = append(userTraitOptions, resource.WithAccountType(v2.UserTrait_ACCOUNT_TYPE_SERVICE))
+	}
+
+	// If the credentials we're hitting the API with don't have admin, this can be false even if the user has mfa enabled
+	// See https://api.slack.com/types/user for more info
+	if user.Has2Fa {
+		userTraitOptions = append(userTraitOptions, resource.WithMFAStatus(&v2.UserTrait_MFAStatus{MfaEnabled: true}))
+	}
+
+	ssoStatus := &v2.UserTrait_SSOStatus{SsoEnabled: false}
+	if user.HasSso {
+		ssoStatus = &v2.UserTrait_SSOStatus{SsoEnabled: true}
+	}
+	userTraitOptions = append(userTraitOptions, resource.WithSSOStatus(ssoStatus))
+
 	ret, err := resource.NewUserResource(user.FullName, resourceTypeUser, user.ID, userTraitOptions)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/user_group.go
+++ b/pkg/connector/user_group.go
@@ -65,7 +65,11 @@ func (o *userGroupResourceType) List(ctx context.Context, parentResourceID *v2.R
 			return nil, "", annos, err
 		}
 	} else {
-		userGroups, err = o.client.GetUserGroupsContext(ctx, slack.GetUserGroupsOptionIncludeUsers(true))
+		opts := []slack.GetUserGroupsOption{
+			slack.GetUserGroupsOptionIncludeUsers(true),
+			slack.GetUserGroupsOptionIncludeDisabled(true),
+		}
+		userGroups, err = o.client.GetUserGroupsContext(ctx, opts...)
 		if err != nil {
 			annos, err := annotationsForError(err)
 			return nil, "", annos, err


### PR DESCRIPTION
- Error if slack account is enterprise but no enterprise key was specified.
- Add more/better logging.
- Fix some url.JoinPath() calls.
- Remove unused arguments to builder functions.
