### PR TITLE
Fixes syncing member role grants

### DIFF
--- a/pkg/connector/workspace.go
+++ b/pkg/connector/workspace.go
@@ -194,6 +194,14 @@ func (o *workspaceResourceType) Grants(ctx context.Context, resource *v2.Resourc
 			rv = append(rv, grant.NewGrant(rr, RoleAssignmentEntitlement, userID))
 		}
 
+		if !user.IsRestricted && user.IsUltraRestricted && !user.IsInvitedUser && !user.IsBot && !user.Deleted {
+			rr, err := roleResource(MemberRoleID, resource.Id)
+			if err != nil {
+				return nil, "", nil, err
+			}
+			rv = append(rv, grant.NewGrant(rr, RoleAssignmentEntitlement, userID))
+		}
+
 		if user.IsBot {
 			rr, err := roleResource(BotRoleID, resource.Id)
 			if err != nil {

--- a/pkg/connector/workspace.go
+++ b/pkg/connector/workspace.go
@@ -194,7 +194,7 @@ func (o *workspaceResourceType) Grants(ctx context.Context, resource *v2.Resourc
 			rv = append(rv, grant.NewGrant(rr, RoleAssignmentEntitlement, userID))
 		}
 
-		if !user.IsRestricted && user.IsUltraRestricted && !user.IsInvitedUser && !user.IsBot && !user.Deleted {
+		if !user.IsRestricted && !user.IsUltraRestricted && !user.IsInvitedUser && !user.IsBot && !user.Deleted {
 			rr, err := roleResource(MemberRoleID, resource.Id)
 			if err != nil {
 				return nil, "", nil, err


### PR DESCRIPTION
The code for syncing member role grants somehow managed to get accidentally removed.