### PR TITLE
Removes syncing disabled user groups for the non-enterprise connector

### DIFF
--- a/pkg/connector/user_group.go
+++ b/pkg/connector/user_group.go
@@ -67,7 +67,9 @@ func (o *userGroupResourceType) List(ctx context.Context, parentResourceID *v2.R
 	} else {
 		opts := []slack.GetUserGroupsOption{
 			slack.GetUserGroupsOptionIncludeUsers(true),
-			slack.GetUserGroupsOptionIncludeDisabled(true),
+			// We need to add a way to signify disabled resources in baton in order to include disabled groups
+			// We should also be doing this for both enterprise and non-enterprise groups
+			// slack.GetUserGroupsOptionIncludeDisabled(true),
 		}
 		userGroups, err = o.client.GetUserGroupsContext(ctx, opts...)
 		if err != nil {


### PR DESCRIPTION
A customer was running into an issue when syncing grants for user groups. This appears to be because we sync user groups that are disabled for the non-enterprise connector, but we do not include disabled groups when hitting the API for listing grants. This results in not being able to find the user group. This PR removes syncing disabled user groups, as we are not properly marking them as disabled currently, and it does not appear that we sync these for the enterprise version of the connector. 