### PR TITLE
Fixes enterprise roles

### DIFF
--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -1,6 +1,7 @@
 package connector
 
 import (
+	"encoding/json"
 	"errors"
 	"time"
 
@@ -12,6 +13,51 @@ import (
 
 	enterprise "github.com/conductorone/baton-slack/pkg/slack"
 )
+
+type enterpriseRolesPagination struct {
+	Cursor   string          `json:"cursor"`
+	FoundMap map[string]bool `json:"foundMap"`
+}
+
+func (e *enterpriseRolesPagination) Marshal() (string, error) {
+	if e.Cursor == "" {
+		return "", nil
+	}
+	bytes, err := json.Marshal(e)
+	if err != nil {
+		return "", err
+	}
+
+	return string(bytes), nil
+}
+
+func (e *enterpriseRolesPagination) Unmarshal(input string) error {
+	if input == "" {
+		e.FoundMap = make(map[string]bool)
+		return nil
+	}
+
+	err := json.Unmarshal([]byte(input), e)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func parseRolesPageToken(i string, resourceID *v2.ResourceId) (*enterpriseRolesPagination, error) {
+	b := &enterpriseRolesPagination{}
+	err := b.Unmarshal(i)
+	if err != nil {
+		return nil, err
+	}
+
+	if b.FoundMap == nil {
+		b.FoundMap = make(map[string]bool)
+	}
+
+	return b, nil
+}
 
 func parsePageToken(i string, resourceID *v2.ResourceId) (*pagination.Bag, error) {
 	b := &pagination.Bag{}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -180,8 +180,6 @@ github.com/conductorone/baton-sdk/pkg/ugrpc
 github.com/conductorone/baton-sdk/pkg/uhttp
 github.com/conductorone/baton-sdk/pkg/us3
 github.com/conductorone/baton-sdk/pkg/utls
-# github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
-## explicit
 # github.com/doug-martin/goqu/v9 v9.19.0
 ## explicit; go 1.12
 github.com/doug-martin/goqu/v9

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -180,6 +180,8 @@ github.com/conductorone/baton-sdk/pkg/ugrpc
 github.com/conductorone/baton-sdk/pkg/uhttp
 github.com/conductorone/baton-sdk/pkg/us3
 github.com/conductorone/baton-sdk/pkg/utls
+# github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
+## explicit
 # github.com/doug-martin/goqu/v9 v9.19.0
 ## explicit; go 1.12
 github.com/doug-martin/goqu/v9


### PR DESCRIPTION
Fixes an issue with trying to list grants for enterprise roles that don't always exist in slack. Now we only sync enterprise roles that actually exist in an account. The catch is that we have to use the ListRoleAssignments API, which means we only sync roles that have grants. This should be fine since we don't currently support role provisioning. 