### PR TITLE
Skip entitlements and grants on the user type

### DIFF
--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -1,6 +1,9 @@
 package connector
 
-import v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+import (
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+)
 
 var (
 	resourceTypeUser = &v2.ResourceType{
@@ -9,6 +12,7 @@ var (
 		Traits: []v2.ResourceType_Trait{
 			v2.ResourceType_TRAIT_USER,
 		},
+		Annotations: annotations.New(&v2.SkipEntitlementsAndGrants{}),
 	}
 	resourceTypeWorkspace = &v2.ResourceType{
 		Id:          "workspace",


### PR DESCRIPTION
Save the cycles and don't try to sync entitlements and grants for the user resource type.