### PR TITLE
Only operate on workspaces on which baton is installed

### DIFF
--- a/pkg/connector/client/path.go
+++ b/pkg/connector/client/path.go
@@ -19,6 +19,7 @@ const (
 	UrlPathGetUsersAdmin       = "/api/admin.users.list"
 	UrlPathIDPGroup            = "/scim/v2/Groups/%s"
 	UrlPathIDPGroups           = "/scim/v2/Groups"
+	UrlPathAuthTeamsList       = "/api/auth.teams.list"
 
 	// NOTE: these are only for enterprise grid workspaces
 	// docs: https://api.slack.com/methods/admin.users.setRegular

--- a/pkg/connector/client/slack.go
+++ b/pkg/connector/client/slack.go
@@ -327,6 +327,45 @@ func (c *Client) GetUserGroups(
 	return response.UserGroups, ratelimitData, nil
 }
 
+// GetAuthTeamsList returns the list of teams for which the app is authed.
+func (c *Client) GetAuthTeamsList(
+	ctx context.Context,
+	cursor string,
+) (
+	[]slack.Team,
+	string,
+	*v2.RateLimitDescription,
+	error,
+) {
+	values := map[string]interface{}{}
+
+	if cursor != "" {
+		values["cursor"] = cursor
+	}
+
+	var response struct {
+		BaseResponse
+		Teams []slack.Team `json:"teams"`
+		Pagination
+	}
+
+	ratelimitData, err := c.post(
+		ctx,
+		UrlPathAuthTeamsList,
+		&response,
+		values,
+		false,
+	)
+	if err := response.handleError(err, "fetching authed teams"); err != nil {
+		return nil, "", ratelimitData, err
+	}
+
+	return response.Teams,
+		response.ResponseMetadata.NextCursor,
+		ratelimitData,
+		nil
+}
+
 // SetWorkspaceRole sets the role for the given user in the given team.
 func (c *Client) SetWorkspaceRole(
 	ctx context.Context,

--- a/pkg/connector/workspace.go
+++ b/pkg/connector/workspace.go
@@ -92,7 +92,7 @@ func (o *workspaceResourceType) List(
 	)
 	if o.enterpriseID != "" {
 		outputAnnotations := annotations.New()
-		workspaces, nextCursor, ratelimitData, err = o.enterpriseClient.GetTeams(ctx, bag.PageToken())
+		workspaces, nextCursor, ratelimitData, err = o.enterpriseClient.GetAuthTeamsList(ctx, bag.PageToken())
 		outputAnnotations.WithRateLimiting(ratelimitData)
 		if err != nil {
 			return nil, "", outputAnnotations, err


### PR DESCRIPTION
This changes the workspaceResourceType to only list teams for which it has been authed.

======

We could, alternatively:
* continue to list all teams
* check whether we can call some API for that team (problem here I have yet to find a lightweight call that is good for this)
* filter out teams we get an auth error on and log about it

The last step there could potentially be gated by a config option so that we can preserve existing behavior.
The one bummer is that those logs don't really make their way to anywhere DD or user-visible, so we'd be doing a fair amount of extra work for little benefit.

=======

Other alternative is we still introduce a config option to gate this new behavior, but just use it to decide whether we list all teams (and eventually fail if you are not authed on any of them) vs. use the new endpoint to just get the authed teams.
