### PR TITLE
Better workspace caching.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/slack-go/slack v0.14.0
 	github.com/spf13/viper v1.19.0
 	go.uber.org/zap v1.27.0
+	google.golang.org/grpc v1.70.0
 	google.golang.org/protobuf v1.36.4
 )
 
@@ -102,7 +103,6 @@ require (
 	golang.org/x/text v0.22.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250127172529-29210b9bc287 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250127172529-29210b9bc287 // indirect
-	google.golang.org/grpc v1.70.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -115,7 +115,7 @@ func (o *workspaceRoleType) List(
 }
 
 func (o *workspaceRoleType) Entitlements(
-	_ context.Context,
+	ctx context.Context,
 	resource *v2.Resource,
 	_ *pagination.Token,
 ) (
@@ -124,9 +124,9 @@ func (o *workspaceRoleType) Entitlements(
 	annotations.Annotations,
 	error,
 ) {
-	workspaceName, ok := workspacesNameCache[resource.ParentResourceId.Resource]
-	if !ok {
-		return nil, "", nil, fmt.Errorf("invalid workspace: %s", resource.ParentResourceId.Resource)
+	workspaceName, err := o.enterpriseClient.GetWorkspaceName(ctx, o.client, resource.ParentResourceId.Resource)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("error getting workspace name for workspace id %s: %w", resource.ParentResourceId.Resource, err)
 	}
 	return []*v2.Entitlement{
 			entitlement.NewAssignmentEntitlement(

--- a/pkg/connector/workspace.go
+++ b/pkg/connector/workspace.go
@@ -15,8 +15,6 @@ import (
 	"github.com/slack-go/slack"
 )
 
-var workspacesNameCache = make(map[string]string)
-
 const memberEntitlement = "member"
 
 type workspaceResourceType struct {
@@ -113,7 +111,7 @@ func (o *workspaceResourceType) List(
 
 	// Seed the cache.
 	for _, workspace := range workspaces {
-		workspacesNameCache[workspace.ID] = workspace.Name
+		o.enterpriseClient.SetWorkspaceName(workspace.ID, workspace.Name)
 	}
 
 	output, err := pkg.MakeResourceList(


### PR DESCRIPTION
Remove global cache which caused issues when running in temporal.

Caches can miss, so try to populate cache if workspace isn't found in it.

I tested this by commenting out the `c.workspacesNameCache[workspaceID] = workspaceName` in SetWorkspaceName() so we always miss the cache. It works with both slack enterprise and regular slack.