### PR TITLE
[BB-320] baton-slack: return userResource when creating account

### DIFF
--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -270,7 +270,7 @@ func (o *userResourceType) CreateAccount(
 	}
 
 	if o.enterpriseClient == nil {
-		return nil, nil, nil, fmt.Errorf("baton-slack: account provisioning only works for slace enterprise: %w", err)
+		return nil, nil, nil, fmt.Errorf("baton-slack: account provisioning only works for slack enterprise: %w", err)
 	}
 
 	ratelimitData, err := o.enterpriseClient.InviteUserToWorkspace(ctx, params)
@@ -288,12 +288,12 @@ func (o *userResourceType) CreateAccount(
 
 	parentResourceID, err := resource.NewResourceID(resourceTypeWorkspace, params.TeamID)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("baton-slack: create parent resource if failed: %w", err)
+		return nil, nil, nil, fmt.Errorf("baton-slack: create parent resource failed: %w", err)
 	}
 
 	r, err := userResource(ctx, user, parentResourceID)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("baton-slack: cannot create connector resource: %w", err)
+		return nil, nil, nil, fmt.Errorf("baton-slack: cannot create user resource: %w", err)
 	}
 
 	return &v2.CreateAccountResponse_SuccessResult{


### PR DESCRIPTION
Recently, we found a bug that crashes c1 web page because the resource ID is empty.
The fix is [here](https://github.com/ductone/c1/pull/8488)

When I take a look at the connector code, I found we returned empty resource while creating accounts. 
That's why resource ID is empty.

In this PR, I fixed the issue by returning user resource when creating account.

Tested in 
<img width="1384" alt="image" src="https://github.com/user-attachments/assets/e4dee367-79cb-4371-90f4-ad73146e28bb" />

