### PR TITLE
remove delete

### DIFF
--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -301,11 +301,6 @@ func (o *userResourceType) CreateAccount(
 	}, nil, outputAnnotations, nil
 }
 
-// Delete user can't be done via the Slack API.
-func (o *userResourceType) Delete(ctx context.Context, resourceId *v2.ResourceId) (annotations.Annotations, error) {
-	return nil, fmt.Errorf("baton-slack: delete user not supported")
-}
-
 func (o *userResourceType) CreateAccountCapabilityDetails(ctx context.Context) (*v2.CredentialDetailsAccountProvisioning, annotations.Annotations, error) {
 	return &v2.CredentialDetailsAccountProvisioning{
 		SupportedCredentialOptions: []v2.CapabilityDetailCredentialOption{

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -301,30 +301,9 @@ func (o *userResourceType) CreateAccount(
 	}, nil, outputAnnotations, nil
 }
 
+// Delete user can't be done via the Slack API.
 func (o *userResourceType) Delete(ctx context.Context, resourceId *v2.ResourceId) (annotations.Annotations, error) {
-	if o.enterpriseClient == nil {
-		return nil, fmt.Errorf("baton-slack: enterprise client required for user deletion")
-	}
-
-	userID := resourceId.Resource
-	outputAnnotations := annotations.New()
-
-	user, ratelimitData, err := o.enterpriseClient.GetUserInfo(ctx, userID)
-	outputAnnotations.WithRateLimiting(ratelimitData)
-	if err != nil {
-		return outputAnnotations, fmt.Errorf("baton-slack: failed to get user info: %w", err)
-	}
-
-	ratelimitData, err = o.enterpriseClient.RemoveUser(ctx, user.Profile.Team, userID)
-	outputAnnotations.WithRateLimiting(ratelimitData)
-	if err != nil {
-		if err.Error() == enterprise.SlackErrUserAlreadyDeleted {
-			return outputAnnotations, nil
-		}
-		return outputAnnotations, fmt.Errorf("baton-slack: failed to delete user %s: %w", userID, err)
-	}
-
-	return outputAnnotations, nil
+	return nil, fmt.Errorf("baton-slack: delete user not supported")
 }
 
 func (o *userResourceType) CreateAccountCapabilityDetails(ctx context.Context) (*v2.CredentialDetailsAccountProvisioning, annotations.Annotations, error) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Breaking Changes
  - Deleting users via the Slack integration is no longer supported; delete requests now return an immediate error.

- User Impact
  - Automations or workflows that attempted to delete users will fail with a “delete user not supported” message.
  - Use Slack’s native admin tools for user removal and update any processes accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->