### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -7,6 +7,7 @@ type Slack struct {
 	Token string `mapstructure:"token"`
 	BusinessPlusToken string `mapstructure:"business-plus-token"`
 	GovEnv bool `mapstructure:"gov-env"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *Slack) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,6 +14,11 @@ var (
 		field.WithRequired(true),
 		field.WithIsSecret(true),
 	)
+	BaseURLField = field.StringField(
+		"base-url",
+		field.WithDisplayName("Base URL"),
+		field.WithDescription("Override the Slack API URL (for testing or enterprise deployments)"),
+	)
 	BusinessPlusTokenField = field.StringField(
 		"business-plus-token",
 		field.WithDisplayName("Business Plus Token"),
@@ -34,6 +39,7 @@ var (
 		AccessTokenField,
 		BusinessPlusTokenField,
 		GovEnvironmentField,
+		BaseURLField,
 	}
 
 	// FieldRelationships defines relationships between the fields listed in

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,7 @@ var (
 		field.WithDisplayName("Base URL"),
 		field.WithDescription("Override the Slack API URL (for testing or enterprise deployments)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 	BusinessPlusTokenField = field.StringField(
 		"business-plus-token",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,6 +18,7 @@ var (
 		"base-url",
 		field.WithDisplayName("Base URL"),
 		field.WithDescription("Override the Slack API URL (for testing or enterprise deployments)"),
+		field.WithHidden(true),
 	)
 	BusinessPlusTokenField = field.StringField(
 		"business-plus-token",

--- a/pkg/connector/actions.go
+++ b/pkg/connector/actions.go
@@ -18,6 +18,13 @@ var (
 	ActionEnableUser  = "enable_user"
 )
 
+const (
+	userIDKey      = "user_id"
+	userIDDisplay  = "User ID"
+	successKey     = "success"
+	messageKey     = "message"
+)
+
 var (
 	disableUserSchema = &v2.BatonActionSchema{
 		Name:        ActionDisableUser,
@@ -25,8 +32,8 @@ var (
 		Description: "Deactivate a Slack user account by setting active to false via SCIM API",
 		Arguments: []*config_sdk.Field{
 			{
-				Name:        "user_id",
-				DisplayName: "User ID",
+				Name:        userIDKey,
+				DisplayName: userIDDisplay,
 				Description: "The Slack user ID to disable",
 				IsRequired:  true,
 				Field:       &config_sdk.Field_StringField{},
@@ -34,20 +41,20 @@ var (
 		},
 		ReturnTypes: []*config_sdk.Field{
 			{
-				Name:        "success",
+				Name:        successKey,
 				DisplayName: "Success",
 				Description: "Indicates if the operation was successful",
 				Field:       &config_sdk.Field_BoolField{},
 			},
 			{
-				Name:        "message",
+				Name:        messageKey,
 				DisplayName: "Message",
 				Description: "A descriptive message about the operation result",
 				Field:       &config_sdk.Field_StringField{},
 			},
 			{
-				Name:        "user_id",
-				DisplayName: "User ID",
+				Name:        userIDKey,
+				DisplayName: userIDDisplay,
 				Description: "The Slack user ID that was processed",
 				Field:       &config_sdk.Field_StringField{},
 			},
@@ -62,8 +69,8 @@ var (
 		Description: "Activate a Slack user account by setting active to true via SCIM API",
 		Arguments: []*config_sdk.Field{
 			{
-				Name:        "user_id",
-				DisplayName: "User ID",
+				Name:        userIDKey,
+				DisplayName: userIDDisplay,
 				Description: "The Slack user ID to enable",
 				IsRequired:  true,
 				Field:       &config_sdk.Field_StringField{},
@@ -71,20 +78,20 @@ var (
 		},
 		ReturnTypes: []*config_sdk.Field{
 			{
-				Name:        "success",
+				Name:        successKey,
 				DisplayName: "Success",
 				Description: "Indicates if the operation was successful",
 				Field:       &config_sdk.Field_BoolField{},
 			},
 			{
-				Name:        "message",
+				Name:        messageKey,
 				DisplayName: "Message",
 				Description: "A descriptive message about the operation result",
 				Field:       &config_sdk.Field_StringField{},
 			},
 			{
-				Name:        "user_id",
-				DisplayName: "User ID",
+				Name:        userIDKey,
+				DisplayName: userIDDisplay,
 				Description: "The Slack user ID that was processed",
 				Field:       &config_sdk.Field_StringField{},
 			},
@@ -122,7 +129,7 @@ func (s *Slack) handleDisableUser(
 ) (*structpb.Struct, annotations.Annotations, error) {
 	l := ctxzap.Extract(ctx)
 
-	userIDValue, ok := args.Fields["user_id"]
+	userIDValue, ok := args.Fields[userIDKey]
 	if !ok {
 		return nil, nil, fmt.Errorf("user_id parameter is required")
 	}
@@ -132,7 +139,7 @@ func (s *Slack) handleDisableUser(
 		return nil, nil, fmt.Errorf("user_id cannot be empty")
 	}
 
-	l.Debug("disabling user via SCIM", zap.String("user_id", userID))
+	l.Debug("disabling user via SCIM", zap.String(userIDKey, userID))
 
 	if s.businessPlusClient == nil {
 		return nil, nil, fmt.Errorf("business+ client not available - SCIM API requires Business+ plan")
@@ -140,7 +147,7 @@ func (s *Slack) handleDisableUser(
 
 	ratelimitData, err := s.businessPlusClient.DisableUser(ctx, userID)
 	if err != nil {
-		l.Error("failed to disable user", zap.String("user_id", userID), zap.Error(err))
+		l.Error("failed to disable user", zap.String(userIDKey, userID), zap.Error(err))
 		return nil, nil, fmt.Errorf("failed to disable user %s: %w", userID, err)
 	}
 
@@ -149,13 +156,13 @@ func (s *Slack) handleDisableUser(
 		outputAnnotations.WithRateLimiting(ratelimitData)
 	}
 
-	l.Info("user disabled successfully", zap.String("user_id", userID))
+	l.Info("user disabled successfully", zap.String(userIDKey, userID))
 
 	return &structpb.Struct{
 		Fields: map[string]*structpb.Value{
-			"success": {Kind: &structpb.Value_BoolValue{BoolValue: true}},
-			"message": {Kind: &structpb.Value_StringValue{StringValue: fmt.Sprintf("User %s disabled successfully", userID)}},
-			"user_id": {Kind: &structpb.Value_StringValue{StringValue: userID}},
+			successKey: {Kind: &structpb.Value_BoolValue{BoolValue: true}},
+			messageKey: {Kind: &structpb.Value_StringValue{StringValue: fmt.Sprintf("User %s disabled successfully", userID)}},
+			userIDKey: {Kind: &structpb.Value_StringValue{StringValue: userID}},
 		},
 	}, outputAnnotations, nil
 }
@@ -167,7 +174,7 @@ func (s *Slack) handleEnableUser(
 ) (*structpb.Struct, annotations.Annotations, error) {
 	l := ctxzap.Extract(ctx)
 
-	userIDValue, ok := args.Fields["user_id"]
+	userIDValue, ok := args.Fields[userIDKey]
 	if !ok {
 		return nil, nil, fmt.Errorf("user_id parameter is required")
 	}
@@ -177,7 +184,7 @@ func (s *Slack) handleEnableUser(
 		return nil, nil, fmt.Errorf("user_id cannot be empty")
 	}
 
-	l.Debug("enabling user via SCIM", zap.String("user_id", userID))
+	l.Debug("enabling user via SCIM", zap.String(userIDKey, userID))
 
 	if s.businessPlusClient == nil {
 		return nil, nil, fmt.Errorf("business+ client not available - SCIM API requires Business+ plan")
@@ -185,7 +192,7 @@ func (s *Slack) handleEnableUser(
 
 	ratelimitData, err := s.businessPlusClient.EnableUser(ctx, userID)
 	if err != nil {
-		l.Error("failed to enable user", zap.String("user_id", userID), zap.Error(err))
+		l.Error("failed to enable user", zap.String(userIDKey, userID), zap.Error(err))
 		return nil, nil, fmt.Errorf("failed to enable user %s: %w", userID, err)
 	}
 
@@ -194,13 +201,13 @@ func (s *Slack) handleEnableUser(
 		outputAnnotations.WithRateLimiting(ratelimitData)
 	}
 
-	l.Info("user enabled successfully", zap.String("user_id", userID))
+	l.Info("user enabled successfully", zap.String(userIDKey, userID))
 
 	return &structpb.Struct{
 		Fields: map[string]*structpb.Value{
-			"success": {Kind: &structpb.Value_BoolValue{BoolValue: true}},
-			"message": {Kind: &structpb.Value_StringValue{StringValue: fmt.Sprintf("User %s enabled successfully", userID)}},
-			"user_id": {Kind: &structpb.Value_StringValue{StringValue: userID}},
+			successKey: {Kind: &structpb.Value_BoolValue{BoolValue: true}},
+			messageKey: {Kind: &structpb.Value_StringValue{StringValue: fmt.Sprintf("User %s enabled successfully", userID)}},
+			userIDKey: {Kind: &structpb.Value_StringValue{StringValue: userID}},
 		},
 	}, outputAnnotations, nil
 }

--- a/pkg/connector/client/slack.go
+++ b/pkg/connector/client/slack.go
@@ -24,6 +24,9 @@ const (
 	SlackErrNoSuchSubteam = "no_such_subteam"
 	ScimVersionV2         = "v2"
 	ScimVersionV1         = "v1"
+
+	teamIDKey       = "team_id"
+	scimPatchOpURN  = "urn:ietf:params:scim:api:messages:2.0:PatchOp"
 )
 
 var workspaceNameNamespace = sessions.WithPrefix("workspace_name")
@@ -120,7 +123,7 @@ func (c *Client) GetUserGroupMembers(
 		UrlPathGetUserGroupMembers,
 		&response,
 		map[string]interface{}{
-			"team_id":   teamID,
+			teamIDKey: teamID,
 			"usergroup": userGroupID,
 		},
 		true,
@@ -143,7 +146,7 @@ func (c *Client) GetUsers(
 	*v2.RateLimitDescription,
 	error,
 ) {
-	values := map[string]interface{}{"team_id": teamID}
+	values := map[string]interface{}{teamIDKey: teamID}
 
 	// need to check if cursor is empty because API throws error if empty string is passed
 	if cursor != "" {
@@ -191,7 +194,7 @@ func (c *Client) GetUserGroups(
 		ctx,
 		UrlPathGetUserGroups,
 		&response,
-		map[string]interface{}{"team_id": teamID},
+		map[string]interface{}{teamIDKey: teamID},
 		true,
 	)
 	if err != nil {
@@ -347,7 +350,7 @@ func (c *Client) AddUserToGroup(
 	members = append(members, UserID{Value: user})
 
 	requestBody := PatchOp{
-		Schemas: []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+		Schemas: []string{scimPatchOpURN},
 		Operations: []ScimOperate{
 			{
 				Op:    "add",
@@ -395,7 +398,7 @@ func (c *Client) RemoveUserFromGroup(
 	}
 
 	requestBody := PatchOp{
-		Schemas: []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+		Schemas: []string{scimPatchOpURN},
 		Operations: []ScimOperate{
 			{
 				Op:   "remove",
@@ -480,7 +483,7 @@ func (c *Client) EnableUser(
 	error,
 ) {
 	requestBody := map[string]any{
-		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+		"schemas": []string{scimPatchOpURN},
 		"Operations": []map[string]any{
 			{
 				"path":  "active",


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-slack --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.