### PR TITLE
CXH-434: map no_such_subteam to Unavailable for retry support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,5 +20,5 @@ jobs:
         with:
           connector: ./baton-slack
           baton-entitlement: 'group:S0A1RHL4CP5:member'
-          baton-principal: 'U0847EPUZ0R'
+          baton-principal: 'U0A3NPX9Z5L'
           baton-principal-type: 'user'

--- a/pkg/connector/actions.go
+++ b/pkg/connector/actions.go
@@ -8,7 +8,6 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/actions"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -96,26 +95,24 @@ var (
 	}
 )
 
-func (s *Slack) RegisterActionManager(ctx context.Context) (connectorbuilder.CustomActionManager, error) {
+func (s *Slack) GlobalActions(ctx context.Context, registry actions.ActionRegistry) error {
 	l := ctxzap.Extract(ctx)
 
-	actionManager := actions.NewActionManager(ctx)
-
-	err := actionManager.RegisterAction(ctx, ActionDisableUser, disableUserSchema, s.handleDisableUser)
+	err := registry.Register(ctx, disableUserSchema, s.handleDisableUser)
 	if err != nil {
 		l.Error("failed to register disable_user action", zap.Error(err))
-		return nil, err
+		return err
 	}
 	l.Info("registered disable_user action")
 
-	err = actionManager.RegisterAction(ctx, ActionEnableUser, enableUserSchema, s.handleEnableUser)
+	err = registry.Register(ctx, enableUserSchema, s.handleEnableUser)
 	if err != nil {
 		l.Error("failed to register enable_user action", zap.Error(err))
-		return nil, err
+		return err
 	}
 
 	l.Info("registered enable_user action")
-	return actionManager, nil
+	return nil
 }
 
 // handleDisableUser deactivates a Slack user by setting active to false via SCIM API.

--- a/pkg/connector/client/helpers.go
+++ b/pkg/connector/client/helpers.go
@@ -126,6 +126,11 @@ func MapSlackErrorToGRPCCode(slackError string) codes.Code {
 		return codes.NotFound
 	}
 
+	// no_such_subteam is a transient error - map to Unavailable to trigger SDK retry (CXH-434).
+	if containsAny(err, SlackErrNoSuchSubteam) {
+		return codes.Unavailable
+	}
+
 	if containsAny(err, "user_already_team_member") {
 		return codes.AlreadyExists
 	}

--- a/pkg/connector/client/helpers.go
+++ b/pkg/connector/client/helpers.go
@@ -126,7 +126,9 @@ func MapSlackErrorToGRPCCode(slackError string) codes.Code {
 		return codes.NotFound
 	}
 
-	// no_such_subteam is a transient error - map to Unavailable to trigger SDK retry (CXH-434).
+	// no_such_subteam is returned when fetching user group members. We determined
+	// empirically that retrying on this error allows syncs to complete successfully,
+	// so we map it to Unavailable to trigger the SDK's automatic retry logic.
 	if containsAny(err, SlackErrNoSuchSubteam) {
 		return codes.Unavailable
 	}

--- a/pkg/connector/client/slack.go
+++ b/pkg/connector/client/slack.go
@@ -19,7 +19,8 @@ const (
 	// Slack API error string constants.
 	SlackErrUserAlreadyTeamMember = "user_already_team_member"
 	SlackErrUserAlreadyDeleted    = "user_already_deleted"
-	// SlackErrNoSuchSubteam is returned when a user group is temporarily unreachable (CXH-434).
+	// SlackErrNoSuchSubteam is returned when fetching user group members. Retrying
+	// on this error was determined empirically to allow syncs to complete.
 	SlackErrNoSuchSubteam = "no_such_subteam"
 	ScimVersionV2         = "v2"
 	ScimVersionV1         = "v1"

--- a/pkg/connector/client/slack.go
+++ b/pkg/connector/client/slack.go
@@ -19,8 +19,10 @@ const (
 	// Slack API error string constants.
 	SlackErrUserAlreadyTeamMember = "user_already_team_member"
 	SlackErrUserAlreadyDeleted    = "user_already_deleted"
-	ScimVersionV2                 = "v2"
-	ScimVersionV1                 = "v1"
+	// SlackErrNoSuchSubteam is returned when a user group is temporarily unreachable (CXH-434).
+	SlackErrNoSuchSubteam = "no_such_subteam"
+	ScimVersionV2         = "v2"
+	ScimVersionV1         = "v1"
 )
 
 var workspaceNameNamespace = sessions.WithPrefix("workspace_name")


### PR DESCRIPTION
## Summary

- `no_such_subteam` is a transient Slack API error returned when fetching user group members
- Previously it fell through `MapSlackErrorToGRPCCode` and returned `codes.Unknown`, causing syncs to hard-fail
- Maps it to `codes.Unavailable` so the SDK triggers automatic retry logic

## Test plan

- [x] `go build ./...` passes
- [x] `golangci-lint run` passes with 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Connector now treats missing subteam responses as transient errors, enabling automatic retries and reducing synchronization disruptions.

* **Refactor**
  * Action registration simplified to a centralized registry-style entry point, streamlining how actions are registered and initialized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->