### PR TITLE
docs: update connector documentation style

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -11,7 +11,7 @@ sidebarTitle: Slack
 
 (We also have an connector for [Slack Enterprise Grid accounts](/baton/slack-enterprise).) 
 
-If you want to install the C1 Slack app, so that you and your colleagues can request access and get notifications about new C1 tasks in your Slack workspace, go to the **Settings** page in C1 and click **Notifications**.
+If you want to install the C1 app for Slack, so that you and your colleagues can request access and get notifications about new C1 tasks in your Slack workspace, go to the **Settings** page in C1 and click **Notifications**.
 </Warning>
 
 ## Capabilities
@@ -115,7 +115,7 @@ When prompted, allow your new app to access the Slack workspace.
 Your user OAuth token is created. Copy and save the token value. 
 </Step>
 </Steps>
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the Slack connector
 
@@ -159,13 +159,13 @@ Click **Next**.
 Find the **Settings** area of the page and click **Edit**.
 </Step>
 <Step>
+**Pro users only:** Paste the token into the **Access token** field. 
+</Step>
+<Step>
 **Business+ users only:** Paste the token into the **Business plus token** field.
 </Step>
 <Step>
-If you're using a GovSlack instance, click the checkmark to **Enable GovSlack**. 
-</Step>
-<Step>
-**Pro users only:** Paste the token into the **Access token** field. 
+If you're using a GovSlack instance, select the **Gov environment** checkbox. 
 </Step>
 <Step>
 Click **Save**.
@@ -174,7 +174,7 @@ Click **Save**.
 The connector's label changes to **Syncing**, followed by **Connected**. You can view the logs to ensure that information is syncing.
 </Step>
 </Steps>
-**That's it!** Your Slack connector is now pulling access data into C1.
+**Done.** Your Slack connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 
@@ -296,6 +296,6 @@ Create a namespace in which to run C1 connectors (if desired), then apply the se
 Check that the connector data uploaded correctly. In C1, click **Apps**. On the **Managed apps** tab, locate and click the name of the application you added the Slack connector to. Slack data should be found on the **Entitlements** and **Accounts** tabs.
 </Step>
 </Steps>
-**That's it!** Your Slack connector is now pulling access data into C1.
+**Done.** Your Slack connector is now pulling access data into C1.
 </Tab>
 </Tabs>


### PR DESCRIPTION
## Summary

- Updated phrasing from "That's it!" to "Done." for step completion markers
- Updated app name reference from "C1 Slack app" to "C1 app for Slack"
- Reordered cloud-hosted token fields (Pro first, then Business+) and updated GovSlack checkbox label
- Added trailing newline to end of file