### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/actions.go
+++ b/pkg/connector/actions.go
@@ -19,10 +19,10 @@ var (
 )
 
 const (
-	userIDKey      = "user_id"
-	userIDDisplay  = "User ID"
-	successKey     = "success"
-	messageKey     = "message"
+	userIDKey     = "user_id"
+	userIDDisplay = "User ID"
+	successKey    = "success"
+	messageKey    = "message"
 )
 
 var (
@@ -162,7 +162,7 @@ func (s *Slack) handleDisableUser(
 		Fields: map[string]*structpb.Value{
 			successKey: {Kind: &structpb.Value_BoolValue{BoolValue: true}},
 			messageKey: {Kind: &structpb.Value_StringValue{StringValue: fmt.Sprintf("User %s disabled successfully", userID)}},
-			userIDKey: {Kind: &structpb.Value_StringValue{StringValue: userID}},
+			userIDKey:  {Kind: &structpb.Value_StringValue{StringValue: userID}},
 		},
 	}, outputAnnotations, nil
 }
@@ -207,7 +207,7 @@ func (s *Slack) handleEnableUser(
 		Fields: map[string]*structpb.Value{
 			successKey: {Kind: &structpb.Value_BoolValue{BoolValue: true}},
 			messageKey: {Kind: &structpb.Value_StringValue{StringValue: fmt.Sprintf("User %s enabled successfully", userID)}},
-			userIDKey: {Kind: &structpb.Value_StringValue{StringValue: userID}},
+			userIDKey:  {Kind: &structpb.Value_StringValue{StringValue: userID}},
 		},
 	}, outputAnnotations, nil
 }

--- a/pkg/connector/client/slack.go
+++ b/pkg/connector/client/slack.go
@@ -25,8 +25,8 @@ const (
 	ScimVersionV2         = "v2"
 	ScimVersionV1         = "v1"
 
-	teamIDKey       = "team_id"
-	scimPatchOpURN  = "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+	teamIDKey      = "team_id"
+	scimPatchOpURN = "urn:ietf:params:scim:api:messages:2.0:PatchOp"
 )
 
 var workspaceNameNamespace = sessions.WithPrefix("workspace_name")
@@ -123,7 +123,7 @@ func (c *Client) GetUserGroupMembers(
 		UrlPathGetUserGroupMembers,
 		&response,
 		map[string]interface{}{
-			teamIDKey: teamID,
+			teamIDKey:   teamID,
 			"usergroup": userGroupID,
 		},
 		true,

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -48,14 +48,13 @@ func groupResource(
 		group.DisplayName,
 		resourceTypeGroup,
 		group.ID,
-		[]resources.GroupTraitOption{
-			resources.WithGroupProfile(
-				map[string]interface{}{
-					"group_id":   group.ID,
-					"group_name": group.DisplayName,
-				},
-			),
-		},
+		[]resources.GroupTraitOption{},
+		resources.WithResourceProfile(
+			map[string]interface{}{
+				"group_id":   group.ID,
+				"group_name": group.DisplayName,
+			},
+		),
 	)
 }
 

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -55,9 +55,7 @@ func (o *userResourceType) scimUserResource(ctx context.Context, scimUser client
 	}
 
 	userTraitOptions := []resource.UserTraitOption{
-		resource.WithUserProfile(profile),
 		resource.WithEmail(slackUser.Profile.Email, true),
-		resource.WithStatus(userStatus),
 	}
 
 	if slackUser.IsBot {
@@ -82,6 +80,8 @@ func (o *userResourceType) scimUserResource(ctx context.Context, scimUser client
 		resourceTypeUser,
 		slackUser.ID,
 		userTraitOptions,
+		resource.WithResourceProfile(profile),
+		resource.WithResourceStatus(v2.Status_ResourceStatus(userStatus), ""),
 		resource.WithParentResourceID(parentResourceID),
 	)
 }
@@ -117,9 +117,7 @@ func userResource(
 	}
 
 	userTraitOptions := []resource.UserTraitOption{
-		resource.WithUserProfile(profile),
 		resource.WithEmail(user.Profile.Email, true),
-		resource.WithStatus(userStatus),
 	}
 
 	if user.IsBot {
@@ -144,6 +142,8 @@ func userResource(
 		resourceTypeUser,
 		user.ID,
 		userTraitOptions,
+		resource.WithResourceProfile(profile),
+		resource.WithResourceStatus(v2.Status_ResourceStatus(userStatus), ""),
 		resource.WithParentResourceID(parentResourceID),
 	)
 }

--- a/pkg/connector/user_group.go
+++ b/pkg/connector/user_group.go
@@ -48,15 +48,14 @@ func userGroupResource(
 		userGroup.Name,
 		resourceTypeUserGroup,
 		userGroup.ID,
-		[]resource.GroupTraitOption{
-			resource.WithGroupProfile(
-				map[string]interface{}{
-					"userGroup_id":     userGroup.ID,
-					"userGroup_name":   userGroup.Name,
-					"userGroup_handle": userGroup.Handle,
-				},
-			),
-		},
+		[]resource.GroupTraitOption{},
+		resource.WithResourceProfile(
+			map[string]interface{}{
+				"userGroup_id":     userGroup.ID,
+				"userGroup_name":   userGroup.Name,
+				"userGroup_handle": userGroup.Handle,
+			},
+		),
 		resource.WithParentResourceID(parentResourceID),
 	)
 }

--- a/pkg/connector/workspace.go
+++ b/pkg/connector/workspace.go
@@ -47,15 +47,14 @@ func workspaceResource(
 		workspace.Name,
 		resourceTypeWorkspace,
 		workspace.ID,
-		[]resources.GroupTraitOption{
-			resources.WithGroupProfile(
-				map[string]interface{}{
-					"workspace_id":     workspace.ID,
-					"workspace_name":   workspace.Name,
-					"workspace_domain": workspace.Domain,
-				},
-			),
-		},
+		[]resources.GroupTraitOption{},
+		resources.WithResourceProfile(
+			map[string]interface{}{
+				"workspace_id":     workspace.ID,
+				"workspace_name":   workspace.Name,
+				"workspace_domain": workspace.Domain,
+			},
+		),
 		resources.WithAnnotation(
 			&v2.ChildResourceType{ResourceTypeId: resourceTypeUser.Id},
 			&v2.ChildResourceType{ResourceTypeId: resourceTypeUserGroup.Id},


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
