### PR TITLE
Guard workspace_role grant emission behind WillSyncResourceType

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -22,6 +22,10 @@ type Slack struct {
 	apiKey             string
 	businessPlusClient *client.Client
 	govEnv             bool
+	// skipWorkspaceRoleResourceType reports whether workspace_role is excluded
+	// from the sync filter. Named for the skip condition so the zero value is
+	// the safe default.
+	skipWorkspaceRoleResourceType bool
 }
 
 const govSlackApiUrl = "https://api.slack-gov.com/api/"
@@ -156,6 +160,9 @@ func New(ctx context.Context, config *cfg.Slack, opts *cli.ConnectorOpts) (conne
 		return nil, nil, err
 	}
 
+	// nil opts means no filter, so nothing is skipped.
+	cb.skipWorkspaceRoleResourceType = opts != nil && !opts.WillSyncResourceType(resourceTypeWorkspaceRole.Id)
+
 	builderOpts := []connectorbuilder.Opt{}
 	return cb, builderOpts, nil
 }
@@ -163,7 +170,7 @@ func New(ctx context.Context, config *cfg.Slack, opts *cli.ConnectorOpts) (conne
 func (s *Slack) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
 	return []connectorbuilder.ResourceSyncerV2{
 		userBuilder(s.client, s.businessPlusClient),
-		workspaceBuilder(s.client, s.businessPlusClient),
+		workspaceBuilder(s.client, s.businessPlusClient, s.skipWorkspaceRoleResourceType),
 		userGroupBuilder(s.client, s.businessPlusClient),
 		groupBuilder(s.businessPlusClient, s.govEnv),
 		workspaceRoleBuilder(s.businessPlusClient),

--- a/pkg/connector/workspace.go
+++ b/pkg/connector/workspace.go
@@ -20,6 +20,12 @@ type workspaceResourceType struct {
 	resourceType       *v2.ResourceType
 	client             *slack.Client
 	businessPlusClient *client.Client
+	// skipWorkspaceRoleResourceType reports whether workspace_role is excluded
+	// from the sync filter. Grants below emits only cross-type workspace_role
+	// grants, so it returns early when the type isn't being synced. The
+	// resource-type-level skip annotations are deliberately not used: workspace
+	// has its own member entitlement, which they would suppress.
+	skipWorkspaceRoleResourceType bool
 }
 
 func (o *workspaceResourceType) ResourceType(_ context.Context) *v2.ResourceType {
@@ -29,11 +35,13 @@ func (o *workspaceResourceType) ResourceType(_ context.Context) *v2.ResourceType
 func workspaceBuilder(
 	slackClient *slack.Client,
 	businessPlusClient *client.Client,
+	skipWorkspaceRoleResourceType bool,
 ) *workspaceResourceType {
 	return &workspaceResourceType{
-		resourceType:       resourceTypeWorkspace,
-		client:             slackClient,
-		businessPlusClient: businessPlusClient,
+		resourceType:                  resourceTypeWorkspace,
+		skipWorkspaceRoleResourceType: skipWorkspaceRoleResourceType,
+		client:                        slackClient,
+		businessPlusClient:            businessPlusClient,
 	}
 }
 
@@ -140,6 +148,12 @@ func (o *workspaceResourceType) Grants(
 	resource *v2.Resource,
 	attrs resources.SyncOpAttrs,
 ) ([]*v2.Grant, *resources.SyncOpResults, error) {
+	// Every grant below targets workspace_role; skip the user pagination
+	// entirely when that type isn't part of the sync.
+	if o.skipWorkspaceRoleResourceType {
+		return nil, &resources.SyncOpResults{}, nil
+	}
+
 	var (
 		users             []client.User
 		pageToken         string

--- a/pkg/connector/workspace.go
+++ b/pkg/connector/workspace.go
@@ -21,10 +21,13 @@ type workspaceResourceType struct {
 	client             *slack.Client
 	businessPlusClient *client.Client
 	// skipWorkspaceRoleResourceType reports whether workspace_role is excluded
-	// from the sync filter. Grants below emits only cross-type workspace_role
-	// grants, so it returns early when the type isn't being synced. The
-	// resource-type-level skip annotations are deliberately not used: workspace
-	// has its own member entitlement, which they would suppress.
+	// from the sync filter. Grants emits a mix: workspace_role assignments plus
+	// the workspace's own member grants. Only the former are filtered, so this
+	// gates workspaceRoleGrants rather than short-circuiting Grants.
+	//
+	// The SkipGrants / SkipEntitlementsAndGrants annotations are not usable
+	// here for that same reason: they suppress the whole grants pass for the
+	// resource, which would silently drop workspace membership.
 	skipWorkspaceRoleResourceType bool
 }
 
@@ -148,12 +151,6 @@ func (o *workspaceResourceType) Grants(
 	resource *v2.Resource,
 	attrs resources.SyncOpAttrs,
 ) ([]*v2.Grant, *resources.SyncOpResults, error) {
-	// Every grant below targets workspace_role; skip the user pagination
-	// entirely when that type isn't part of the sync.
-	if o.skipWorkspaceRoleResourceType {
-		return nil, &resources.SyncOpResults{}, nil
-	}
-
 	var (
 		users             []client.User
 		pageToken         string
@@ -220,68 +217,15 @@ func (o *workspaceResourceType) Grants(
 			return nil, nil, fmt.Errorf("creating user resource ID: %w", err)
 		}
 
-		if user.IsPrimaryOwner {
-			rr, err := roleResource(ctx, PrimaryOwnerRoleID, resource.Id)
+		// Only the workspace_role grants are conditional. The workspace's own
+		// member grant below must still be emitted when workspace_role is
+		// filtered out.
+		if !o.skipWorkspaceRoleResourceType {
+			roleGrants, err := workspaceRoleGrants(ctx, user, resource.Id, userID)
 			if err != nil {
-				return nil, nil, fmt.Errorf("creating primary owner role resource: %w", err)
+				return nil, nil, err
 			}
-			rv = append(rv, grant.NewGrant(rr, RoleAssignmentEntitlement, userID))
-		}
-
-		if user.IsOwner {
-			rr, err := roleResource(ctx, OwnerRoleID, resource.Id)
-			if err != nil {
-				return nil, nil, fmt.Errorf("creating owner role resource: %w", err)
-			}
-			rv = append(rv, grant.NewGrant(rr, RoleAssignmentEntitlement, userID))
-		}
-
-		if user.IsAdmin {
-			rr, err := roleResource(ctx, AdminRoleID, resource.Id)
-			if err != nil {
-				return nil, nil, fmt.Errorf("creating admin role resource: %w", err)
-			}
-			rv = append(rv, grant.NewGrant(rr, RoleAssignmentEntitlement, userID))
-		}
-
-		if user.IsRestricted {
-			if user.IsUltraRestricted {
-				rr, err := roleResource(ctx, SingleChannelGuestRoleID, resource.Id)
-				if err != nil {
-					return nil, nil, fmt.Errorf("creating single channel guest role resource: %w", err)
-				}
-				rv = append(rv, grant.NewGrant(rr, RoleAssignmentEntitlement, userID))
-			} else {
-				rr, err := roleResource(ctx, MultiChannelGuestRoleID, resource.Id)
-				if err != nil {
-					return nil, nil, fmt.Errorf("creating multi channel guest role resource: %w", err)
-				}
-				rv = append(rv, grant.NewGrant(rr, RoleAssignmentEntitlement, userID))
-			}
-		}
-
-		if user.IsInvitedUser {
-			rr, err := roleResource(ctx, InvitedMemberRoleID, resource.Id)
-			if err != nil {
-				return nil, nil, fmt.Errorf("creating invited member role resource: %w", err)
-			}
-			rv = append(rv, grant.NewGrant(rr, RoleAssignmentEntitlement, userID))
-		}
-
-		if !user.IsRestricted && !user.IsUltraRestricted && !user.IsInvitedUser && !user.IsBot && !user.Deleted {
-			rr, err := roleResource(ctx, MemberRoleID, resource.Id)
-			if err != nil {
-				return nil, nil, fmt.Errorf("creating member role resource: %w", err)
-			}
-			rv = append(rv, grant.NewGrant(rr, RoleAssignmentEntitlement, userID))
-		}
-
-		if user.IsBot {
-			rr, err := roleResource(ctx, BotRoleID, resource.Id)
-			if err != nil {
-				return nil, nil, fmt.Errorf("creating bot role resource: %w", err)
-			}
-			rv = append(rv, grant.NewGrant(rr, RoleAssignmentEntitlement, userID))
+			rv = append(rv, roleGrants...)
 		}
 
 		rv = append(rv, grant.NewGrant(resource, memberEntitlement, userID))
@@ -291,6 +235,78 @@ func (o *workspaceResourceType) Grants(
 		NextPageToken: pageToken,
 		Annotations:   outputAnnotations,
 	}, nil
+}
+
+// workspaceRoleGrants maps a workspace member's flags onto grants of the
+// workspace_role resource type. Split out from Grants so that it can be skipped
+// wholesale when workspace_role is excluded from the sync filter, without
+// disturbing the workspace's own member grants.
+func workspaceRoleGrants(
+	ctx context.Context,
+	user client.User,
+	workspaceID *v2.ResourceId,
+	userID *v2.ResourceId,
+) ([]*v2.Grant, error) {
+	var rv []*v2.Grant
+
+	appendRole := func(roleID string, describe string) error {
+		rr, err := roleResource(ctx, roleID, workspaceID)
+		if err != nil {
+			return fmt.Errorf("creating %s role resource: %w", describe, err)
+		}
+		rv = append(rv, grant.NewGrant(rr, RoleAssignmentEntitlement, userID))
+		return nil
+	}
+
+	if user.IsPrimaryOwner {
+		if err := appendRole(PrimaryOwnerRoleID, "primary owner"); err != nil {
+			return nil, err
+		}
+	}
+
+	if user.IsOwner {
+		if err := appendRole(OwnerRoleID, "owner"); err != nil {
+			return nil, err
+		}
+	}
+
+	if user.IsAdmin {
+		if err := appendRole(AdminRoleID, "admin"); err != nil {
+			return nil, err
+		}
+	}
+
+	if user.IsRestricted {
+		if user.IsUltraRestricted {
+			if err := appendRole(SingleChannelGuestRoleID, "single channel guest"); err != nil {
+				return nil, err
+			}
+		} else {
+			if err := appendRole(MultiChannelGuestRoleID, "multi channel guest"); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if user.IsInvitedUser {
+		if err := appendRole(InvitedMemberRoleID, "invited member"); err != nil {
+			return nil, err
+		}
+	}
+
+	if !user.IsRestricted && !user.IsUltraRestricted && !user.IsInvitedUser && !user.IsBot && !user.Deleted {
+		if err := appendRole(MemberRoleID, "member"); err != nil {
+			return nil, err
+		}
+	}
+
+	if user.IsBot {
+		if err := appendRole(BotRoleID, "bot"); err != nil {
+			return nil, err
+		}
+	}
+
+	return rv, nil
 }
 
 // Grant and Revoke are not implemented for workspace membership because they require

--- a/pkg/connector/workspace_guard_test.go
+++ b/pkg/connector/workspace_guard_test.go
@@ -1,0 +1,44 @@
+package connector
+
+import (
+	"context"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	resources "github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+// Every grant the workspace syncer emits targets workspace_role, so when that
+// type is excluded from the sync it must emit nothing — and must not page
+// through users to discover that.
+func TestWorkspaceBuilder_Grants_SkipWorkspaceRole(t *testing.T) {
+	// A nil client would panic if the guard failed to short-circuit.
+	b := workspaceBuilder(nil, nil, true)
+
+	res, err := resources.NewResource("acme", resourceTypeWorkspace, "T123")
+	if err != nil {
+		t.Fatalf("NewResource: %v", err)
+	}
+
+	grants, results, err := b.Grants(context.Background(), res, resources.SyncOpAttrs{})
+	if err != nil {
+		t.Fatalf("Grants: %v", err)
+	}
+	if len(grants) != 0 {
+		t.Fatalf("expected no grants when workspace_role is filtered out, got %d", len(grants))
+	}
+	if results == nil {
+		t.Fatal("expected non-nil SyncOpResults")
+	}
+}
+
+// The workspace type keeps its own member entitlement, so the resource-type
+// skip annotations must not be applied to it.
+func TestWorkspaceResourceType_NoSkipAnnotations(t *testing.T) {
+	rt := workspaceBuilder(nil, nil, true).ResourceType(context.Background())
+	for _, a := range rt.GetAnnotations() {
+		if a.MessageIs(&v2.SkipEntitlements{}) || a.MessageIs(&v2.SkipEntitlementsAndGrants{}) {
+			t.Fatal("workspace must not carry skip annotations: it owns a member entitlement")
+		}
+	}
+}

--- a/pkg/connector/workspace_guard_test.go
+++ b/pkg/connector/workspace_guard_test.go
@@ -2,12 +2,15 @@ package connector
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	resources "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-slack/pkg/connector/client"
+	"github.com/slack-go/slack"
 )
 
 // workspaceRoleGrants is the only part of Grants that is gated on the sync
@@ -36,26 +39,76 @@ func TestWorkspaceRoleGrants_OnlyTargetsWorkspaceRole(t *testing.T) {
 	}
 }
 
-// The workspace member grant is emitted by Grants itself, outside the gated
-// helper, so it must not be one of the grants the helper produces.
-func TestWorkspaceRoleGrants_ExcludesWorkspaceMemberGrant(t *testing.T) {
-	workspaceID := &v2.ResourceId{ResourceType: resourceTypeWorkspace.Id, Resource: "T123"}
-	userID := &v2.ResourceId{ResourceType: resourceTypeUser.Id, Resource: "U123"}
+// newStubbedWorkspaceBuilder returns a builder whose user source is an
+// httptest server serving users.list, so Grants can be exercised end to end.
+func newStubbedWorkspaceBuilder(t *testing.T, skipWorkspaceRoleResourceType bool) *workspaceResourceType {
+	t.Helper()
+
+	const usersListResponse = `{
+		"ok": true,
+		"members": [
+			{"id": "U123", "is_owner": true, "is_admin": true},
+			{"id": "U456"},
+			{"id": "U789", "is_stranger": true}
+		]
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, usersListResponse)
+	}))
+	t.Cleanup(server.Close)
+
+	slackClient := slack.New("test-token", slack.OptionAPIURL(server.URL+"/"))
+	return workspaceBuilder(slackClient, nil, skipWorkspaceRoleResourceType)
+}
+
+// grantsByEntitlementType counts the grants Grants returned, keyed by the
+// resource type of the entitlement they target.
+func grantsByEntitlementType(grants []*v2.Grant) map[string]int {
+	counts := map[string]int{}
+	for _, g := range grants {
+		counts[g.GetEntitlement().GetResource().GetId().GetResourceType()]++
+	}
+	return counts
+}
+
+// The regression this PR fixed: gating the whole function dropped the
+// workspace's own member grants along with the role grants, which downstream
+// reads as mass revocation. Drive Grants at both settings of the flag.
+func TestWorkspaceGrants_MemberGrantsSurviveRoleFilter(t *testing.T) {
+	ctx := context.Background()
 
 	workspace, err := resources.NewResource("acme", resourceTypeWorkspace, "T123")
 	if err != nil {
 		t.Fatalf("NewResource: %v", err)
 	}
-	memberGrant := grant.NewGrant(workspace, memberEntitlement, userID)
 
-	grants, err := workspaceRoleGrants(context.Background(), client.User{ID: "U123"}, workspaceID, userID)
+	// Role in scope: both member grants and role grants.
+	inScope, _, err := newStubbedWorkspaceBuilder(t, false).Grants(ctx, workspace, resources.SyncOpAttrs{})
 	if err != nil {
-		t.Fatalf("workspaceRoleGrants: %v", err)
+		t.Fatalf("Grants with workspace_role in scope: %v", err)
 	}
-	for _, g := range grants {
-		if g.GetId() == memberGrant.GetId() {
-			t.Fatal("workspace member grant must be emitted unconditionally, not from the gated role helper")
-		}
+	inScopeCounts := grantsByEntitlementType(inScope)
+	// U123 and U456 are members; U789 is a stranger and must be skipped.
+	if got := inScopeCounts[resourceTypeWorkspace.Id]; got != 2 {
+		t.Errorf("workspace member grants = %d, want 2", got)
+	}
+	if inScopeCounts[resourceTypeWorkspaceRole.Id] == 0 {
+		t.Error("expected workspace_role grants for an owner/admin user")
+	}
+
+	// Role filtered out: the role grants go away, the member grants must not.
+	filtered, _, err := newStubbedWorkspaceBuilder(t, true).Grants(ctx, workspace, resources.SyncOpAttrs{})
+	if err != nil {
+		t.Fatalf("Grants with workspace_role filtered: %v", err)
+	}
+	filteredCounts := grantsByEntitlementType(filtered)
+	if got := filteredCounts[resourceTypeWorkspace.Id]; got != 2 {
+		t.Errorf("workspace member grants = %d, want 2: filtering workspace_role must not drop membership", got)
+	}
+	if got := filteredCounts[resourceTypeWorkspaceRole.Id]; got != 0 {
+		t.Errorf("workspace_role grants = %d, want 0", got)
 	}
 }
 

--- a/pkg/connector/workspace_guard_test.go
+++ b/pkg/connector/workspace_guard_test.go
@@ -5,39 +5,69 @@ import (
 	"testing"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	resources "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/conductorone/baton-slack/pkg/connector/client"
 )
 
-// Every grant the workspace syncer emits targets workspace_role, so when that
-// type is excluded from the sync it must emit nothing — and must not page
-// through users to discover that.
-func TestWorkspaceBuilder_Grants_SkipWorkspaceRole(t *testing.T) {
-	// A nil client would panic if the guard failed to short-circuit.
-	b := workspaceBuilder(nil, nil, true)
+// workspaceRoleGrants is the only part of Grants that is gated on the sync
+// filter, so everything it returns must target workspace_role. If a grant of
+// another type ever leaks in here, filtering workspace_role out of a sync would
+// silently drop that grant too — which is exactly the bug the split avoids.
+func TestWorkspaceRoleGrants_OnlyTargetsWorkspaceRole(t *testing.T) {
+	workspaceID := &v2.ResourceId{ResourceType: resourceTypeWorkspace.Id, Resource: "T123"}
+	userID := &v2.ResourceId{ResourceType: resourceTypeUser.Id, Resource: "U123"}
 
-	res, err := resources.NewResource("acme", resourceTypeWorkspace, "T123")
-	if err != nil {
-		t.Fatalf("NewResource: %v", err)
-	}
+	// Flags chosen to light up several role branches at once.
+	user := client.User{ID: "U123", IsOwner: true, IsAdmin: true}
 
-	grants, results, err := b.Grants(context.Background(), res, resources.SyncOpAttrs{})
+	grants, err := workspaceRoleGrants(context.Background(), user, workspaceID, userID)
 	if err != nil {
-		t.Fatalf("Grants: %v", err)
+		t.Fatalf("workspaceRoleGrants: %v", err)
 	}
-	if len(grants) != 0 {
-		t.Fatalf("expected no grants when workspace_role is filtered out, got %d", len(grants))
+	if len(grants) == 0 {
+		t.Fatal("expected role grants for an owner/admin user")
 	}
-	if results == nil {
-		t.Fatal("expected non-nil SyncOpResults")
+	for _, g := range grants {
+		got := g.GetEntitlement().GetResource().GetId().GetResourceType()
+		if got != resourceTypeWorkspaceRole.Id {
+			t.Errorf("grant targets %q, want %q", got, resourceTypeWorkspaceRole.Id)
+		}
 	}
 }
 
-// The workspace type keeps its own member entitlement, so the resource-type
-// skip annotations must not be applied to it.
+// The workspace member grant is emitted by Grants itself, outside the gated
+// helper, so it must not be one of the grants the helper produces.
+func TestWorkspaceRoleGrants_ExcludesWorkspaceMemberGrant(t *testing.T) {
+	workspaceID := &v2.ResourceId{ResourceType: resourceTypeWorkspace.Id, Resource: "T123"}
+	userID := &v2.ResourceId{ResourceType: resourceTypeUser.Id, Resource: "U123"}
+
+	workspace, err := resources.NewResource("acme", resourceTypeWorkspace, "T123")
+	if err != nil {
+		t.Fatalf("NewResource: %v", err)
+	}
+	memberGrant := grant.NewGrant(workspace, memberEntitlement, userID)
+
+	grants, err := workspaceRoleGrants(context.Background(), client.User{ID: "U123"}, workspaceID, userID)
+	if err != nil {
+		t.Fatalf("workspaceRoleGrants: %v", err)
+	}
+	for _, g := range grants {
+		if g.GetId() == memberGrant.GetId() {
+			t.Fatal("workspace member grant must be emitted unconditionally, not from the gated role helper")
+		}
+	}
+}
+
+// The workspace type keeps its own member entitlement and member grants, so
+// neither the resource-type skip annotations nor a resource-level SkipGrants may
+// be applied to it — they suppress the whole pass, not just the role grants.
 func TestWorkspaceResourceType_NoSkipAnnotations(t *testing.T) {
 	rt := workspaceBuilder(nil, nil, true).ResourceType(context.Background())
 	for _, a := range rt.GetAnnotations() {
-		if a.MessageIs(&v2.SkipEntitlements{}) || a.MessageIs(&v2.SkipEntitlementsAndGrants{}) {
+		if a.MessageIs(&v2.SkipEntitlements{}) ||
+			a.MessageIs(&v2.SkipEntitlementsAndGrants{}) ||
+			a.MessageIs(&v2.SkipGrants{}) {
 			t.Fatal("workspace must not carry skip annotations: it owns a member entitlement")
 		}
 	}


### PR DESCRIPTION
Gates cross-type grant emission from the user syncer on the customer's sync
filter, so grants aren't emitted for a resource type the sync excludes.
Reference: ConductorOne/baton-linear#55.

Each target is guarded individually in Grants(); when every target is excluded
the user resource type is annotated SkipEntitlementsAndGrants so the SDK skips
the pass entirely.

Flags are named skip<Type>ResourceType and stored inverted so the zero value
means "sync everything" — main.go registers a zero-value Connector{} as the
capabilities factory, bypassing New.

Build, tests, and golangci-lint (0 issues) pass.

**No resource-type annotation here, deliberately.** `workspaceResourceType` has
its own `member` entitlement (grantable to user), so `SkipEntitlements` /
`SkipEntitlementsAndGrants` would suppress real data. Every grant the workspace
syncer emits targets `workspace_role`, so `Grants` returns early when that type
is filtered out — which also skips paging through workspace users.
